### PR TITLE
Clear up instructions for editing ~/.profile

### DIFF
--- a/installfest/osx.md
+++ b/installfest/osx.md
@@ -91,6 +91,12 @@ Create a new shell config file.
 touch ~/.profile
 ```
 
+Then open this new file in a text editor such as TextEdit
+
+```text
+open ~/.profile
+```
+
 Put this code inside:
 
 ```text
@@ -110,6 +116,7 @@ function profilerefresh() {
   source ~/.profile
 }
 ```
+Save the file, then close the text editor.
 
 Run this on your terminal:
 


### PR DESCRIPTION
Many students found one step in the installfest to not be clear. I have reworded this section so it's a bit clearer that you create a ~/.profile file, open it with a text editor, and paste some content inside.